### PR TITLE
Set Proper Version of NimBLE

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,7 +5,7 @@ default_envs = esp32s3
 monitor_speed = 115200
 platform = espressif32
 lib_deps =
-  h2zero/NimBLE-Arduino
+  h2zero/NimBLE-Arduino @ 1.4.2
 
 [env:esp32dev]
 framework = arduino


### PR DESCRIPTION
The version of NimBLE is currently not set in `platform.ini`, which means when configuring the project with the current configuration, the following lines error out since these methods of `NimBLEAdvertising` no longer exist in the latest NimBLE version:

```cpp
pAdvertising->setScanResponse(true);
pAdvertising->setMinPreferred(0x12);
pAdvertising->setMinPreferred(0x02);
```

This pull request fixes that by specifying the proper NimBLE version in the `platform.ini`.