### PR TITLE
Lessen Intensity Update Delay

### DIFF
--- a/src/muse.cpp
+++ b/src/muse.cpp
@@ -85,7 +85,7 @@ void muse_advertising_task(void *pvParameters) {
       set_manufacturer_data(_intensity_value);
       // _last_set_intensity_value = _intensity_value;
     // }
-    delay(1000);
+    delay(100);
   }
  
   // advertise stop all channels for a little while


### PR DESCRIPTION
I was using this with XToys until I noticed that when using "fast patterns" (aka, patterns that change the vibrator's intensity rapidly), the vibrator responds only every second which completely defeated the point of fast patterns

I looked into the code and found this! A 1-second delay throttling each update.

This pull request lessens that delay from 1 second to 100ms. I suspect that we can't completely remove this delay, but just 100ms definitely made fast patterns possible.